### PR TITLE
docs: add ignore-file instructions to README

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -21,6 +21,13 @@ Please migrate to the new unified `trivy-scanning.template.yaml`, which provides
 
 The deprecated templates will show migration instructions when used.
 
+#### Ignore-File
+
+In order to use a trivyignore file in YAML-format, the variable `TRIVY_IGNOREFILE must be set and must contain
+the path to the ignorefile relative from the repository-root, because trivy does not load YAML-ignorefiles automatically.  
+Paths inside the YAML-ignore-file are interpreted relative to the path in the `DIRECTORY` variable, you might need to adjust them.  
+Compare the paths in the error-table to the ones in the ignorefile.
+
 ## 🚀 Usage
 
 ### GitLab CI/CD Integration

--- a/README-en.md
+++ b/README-en.md
@@ -23,7 +23,7 @@ The deprecated templates will show migration instructions when used.
 
 #### Ignore-File
 
-In order to use a trivyignore file in YAML-format, the variable `TRIVY_IGNOREFILE must be set and must contain
+In order to use a trivyignore file in YAML-format, the variable `TRIVY_IGNOREFILE` must be set and must contain
 the path to the ignorefile relative from the repository-root, because trivy does not load YAML-ignorefiles automatically.  
 Paths inside the YAML-ignore-file are interpreted relative to the path in the `DIRECTORY` variable, you might need to adjust them.  
 Compare the paths in the error-table to the ones in the ignorefile.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Dieses Repository enthält wiederverwendbare GitLab CI/CD-Templates für Trivy-S
 - **`license-checks.template.yaml`** - ⚠️ **DEPRECATED** - Nutze stattdessen `trivy-scanning.template.yaml`
 - **`security-checks.template.yaml`** - ⚠️ **DEPRECATED** - Nutze stattdessen `trivy-scanning.template.yaml`
 
-### ⚠️ Migration Notice
+### ⚠️ Migrationshinweise
 
 **WICHTIG**: Die individuellen Template-Dateien (`config-checks`, `license-checks`, `security-checks`) sind jetzt **VERALTET**.
 
@@ -20,6 +20,14 @@ Bitte migriere zum neuen unified `trivy-scanning.template.yaml`, welches bietet:
 - Zukunftssicheres Design
 
 Die veralteten Templates zeigen Migrationsanleitungen bei der Verwendung an.
+
+#### Ignore-Datei
+
+Um eine trivyignore Datei im YAML-Format nutzen zu können, muss die Variable `TRIVY_IGNOREFILE` gesetzt sein 
+und den korrekten Pfad relativ zum Repository-Root enthalten, da trivy YAML-Ignorefiles nicht automatisch lädt.  
+Pfade im YAML-Ignorefile werden von trivy relativ zum Verzeichnis aus der `DIRECTORY` Variable interpretiert, 
+eventuell müssen die Pfade angepasst werden.  
+Vergleiche dazu die Pfade in der Fehlertabellle mit denen im Ignore-File.
 
 ## 🚀 Verwendung
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Um eine trivyignore Datei im YAML-Format nutzen zu können, muss die Variable `T
 und den korrekten Pfad relativ zum Repository-Root enthalten, da trivy YAML-Ignorefiles nicht automatisch lädt.  
 Pfade im YAML-Ignorefile werden von trivy relativ zum Verzeichnis aus der `DIRECTORY` Variable interpretiert, 
 eventuell müssen die Pfade angepasst werden.  
-Vergleiche dazu die Pfade in der Fehlertabellle mit denen im Ignore-File.
+Vergleiche dazu die Pfade in der Fehlertabelle mit denen im Ignore-File.
 
 ## 🚀 Verwendung
 


### PR DESCRIPTION
This pull request updates the documentation in both English (`README-en.md`) and German (`README.md`) to clarify migration instructions and provide guidance on using YAML-format trivyignore files with the unified Trivy scanning template. These changes help users correctly configure ignore files and understand path handling, improving the overall usability of the repository.

Migration and ignore file documentation updates:

* Added detailed instructions for using a YAML-format trivyignore file, including how to set the `TRIVY_IGNOREFILE` variable and how paths are interpreted relative to the `DIRECTORY` variable, in both `README-en.md` and `README.md`. [[1]](diffhunk://#diff-423106708231f87bb4bc44163037961a21853bbcda4795297b34f4e0f048cfb6R24-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24-R31)

General documentation improvements:

* Improved migration notice wording in the German `README.md` by changing the section title to "Migrationshinweise" for clarity.