### PR TITLE
feat: add SSH configuration for deploy key in release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
         if: steps.check_release.outputs.create_release == 'true'
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.ACTIONS_DEPLOY_KEY }}" > ~/.ssh/id_rsa
+          printf '%s' "${{ secrets.ACTIONS_DEPLOY_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
           

--- a/.github/workflows/update-plugin.yml
+++ b/.github/workflows/update-plugin.yml
@@ -202,7 +202,7 @@ jobs:
         if: steps.check_update.outputs.update_needed == 'true'
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.ACTIONS_DEPLOY_KEY }}" > ~/.ssh/id_rsa
+          printf '%s' "${{ secrets.ACTIONS_DEPLOY_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
           

--- a/.github/workflows/update-trivy.yml
+++ b/.github/workflows/update-trivy.yml
@@ -205,7 +205,7 @@ jobs:
         if: steps.check_update.outputs.update_needed == 'true'
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.ACTIONS_DEPLOY_KEY }}" > ~/.ssh/id_rsa
+          printf '%s' "${{ secrets.ACTIONS_DEPLOY_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
           


### PR DESCRIPTION
This pull request updates the release and update workflows to use SSH deploy keys for pushing changes to the repository, improving security and reliability for automated commits. The changes affect the `.github/workflows/release.yml`, `.github/workflows/update-plugin.yml`, and `.github/workflows/update-trivy.yml` files. The most important changes are grouped below:

**Security and Deployment Improvements:**

* Added a step to configure SSH for the deploy key before pushing changes in all three workflows, ensuring that pushes use a secure SSH connection with the provided secret (`ACTIONS_DEPLOY_KEY`). [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R212-R219) [[2]](diffhunk://#diff-f4485d7899c86a33585e6ff052b2b390a8c15be072a8ffcf5fd925dc7ac69ddeR201-R208) [[3]](diffhunk://#diff-7d55a15572a4b7c0cbbdf0240b535c677281e84ea5cfe80d12041389cb9dce3dR204-R211)
* Updated the push commands in all workflows to use `GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa"` for pushing changes, ensuring the SSH deploy key is used for authentication. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L233-R242) [[2]](diffhunk://#diff-f4485d7899c86a33585e6ff052b2b390a8c15be072a8ffcf5fd925dc7ac69ddeL221-R230) [[3]](diffhunk://#diff-7d55a15572a4b7c0cbbdf0240b535c677281e84ea5cfe80d12041389cb9dce3dL224-R233)